### PR TITLE
[RHO-4360] audio-lib - Fully remove deprecated log methods - always require channel

### DIFF
--- a/Runtime/AudioManager.cs
+++ b/Runtime/AudioManager.cs
@@ -56,7 +56,7 @@ namespace Padoru.Audio
         {
             if (audioFiles == null)
             {
-                Debug.LogError($"Could not add audio file, the database is null");
+                Debug.LogError($"Could not add audio file, the database is null", Constants.AUDIO_LOG_CHANNEL);
             }
 
             return audioFiles.TryAdd(id, audioFile);
@@ -81,7 +81,7 @@ namespace Padoru.Audio
         {
             if (audioFiles == null)
             {
-                Debug.LogError($"Could not remove audio file, the database is null");
+                Debug.LogError($"Could not remove audio file, the database is null", Constants.AUDIO_LOG_CHANNEL);
             }
 
             if (!audioFiles.ContainsKey(id))

--- a/Runtime/Constants.cs
+++ b/Runtime/Constants.cs
@@ -1,0 +1,7 @@
+namespace Padoru.Audio
+{
+    public static class Constants
+    {
+        public const string AUDIO_LOG_CHANNEL = "PadoruAudio";
+    }
+}

--- a/Runtime/Constants.cs.meta
+++ b/Runtime/Constants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f6d02d8d9a01491d8777c244b64eceb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/PadoruAudioSource.cs
+++ b/Runtime/PadoruAudioSource.cs
@@ -28,25 +28,25 @@ namespace Padoru.Audio
             {
                 if (audioFile == null)
                 {
-                    Debug.LogError("Null audio file");
+                    Debug.LogError("Null audio file", Constants.AUDIO_LOG_CHANNEL);
                     return false;
                 }
 
                 if (audioFile.Clip == null)
                 {
-                    Debug.LogWarning("Null audio clip", gameObject);
+                    Debug.LogWarning("Null audio clip", Constants.AUDIO_LOG_CHANNEL, gameObject);
                     return false;
                 }
 
                 if (isPlaying)
                 {
-                    Debug.LogWarning("Audio is already playing", gameObject);
+                    Debug.LogWarning("Audio is already playing", Constants.AUDIO_LOG_CHANNEL, gameObject);
                     return false;
                 }
 
                 if (audioFile.Disabled)
                 {
-                    Debug.LogWarning("You are trying to play a disabled audio", gameObject);
+                    Debug.LogWarning("You are trying to play a disabled audio", Constants.AUDIO_LOG_CHANNEL, gameObject);
                     return false;
                 }
 
@@ -73,7 +73,7 @@ namespace Padoru.Audio
 
             if (audioManager == null)
             {
-                Debug.LogError("Could not initialize audio source due to null audio manager");
+                Debug.LogError("Could not initialize audio source due to null audio manager", Constants.AUDIO_LOG_CHANNEL);
                 return;
             }
 
@@ -83,7 +83,7 @@ namespace Padoru.Audio
             }
             catch (Exception e)
             {
-                Debug.LogException("Failed to initialize Audio File", e);
+                Debug.LogException("Failed to initialize Audio File", Constants.AUDIO_LOG_CHANNEL, e);
             }
 
             initialized = true;
@@ -133,12 +133,12 @@ namespace Padoru.Audio
             }
             catch (Exception e)
             {
-                Debug.LogException($"Failed to initialize audio source", e);
+                Debug.LogException($"Failed to initialize audio source", Constants.AUDIO_LOG_CHANNEL, e);
             }
 
             if(audioSource == null)
             {
-                Debug.LogError($"Audio manager failed to return an audio source");
+                Debug.LogError($"Audio manager failed to return an audio source", Constants.AUDIO_LOG_CHANNEL);
                 return;
             }
 
@@ -178,7 +178,7 @@ namespace Padoru.Audio
                 }
                 catch (Exception e)
                 {
-                    Debug.LogException($"Failed to return audio source", e);
+                    Debug.LogException($"Failed to return audio source", Constants.AUDIO_LOG_CHANNEL, e);
                 }
 
                 audioSource = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.padoru.audio-lib",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "displayName": "Padoru Audio",
   "description": "A library to manage audio in Unity",
   "unity": "2020.3",


### PR DESCRIPTION
Requires channels to accommodate full removal of deprecated log methods that don't specify channels.
See logger-lib pr for more: https://github.com/series-ai/logger-lib/pull/7